### PR TITLE
Add cron service

### DIFF
--- a/docker-images/php/Dockerfile
+++ b/docker-images/php/Dockerfile
@@ -44,3 +44,16 @@ RUN curl -o magerun https://raw.githubusercontent.com/netz98/n98-magerun/master/
     rm ./magerun && \
     apt-get update && \
     apt-get install -qy mysql-client
+
+# Install cron
+RUN apt-get update && \
+    apt-get install -qy cron
+
+COPY magento-crontab /etc/magento-crontab
+
+RUN crontab /etc/magento-crontab
+
+COPY bin/ /usr/local/bin/
+
+ENTRYPOINT ["entrypoint.sh"]
+CMD ["php-fpm"]

--- a/docker-images/php/bin/entrypoint.sh
+++ b/docker-images/php/bin/entrypoint.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -e
+
+service cron start
+
+docker-php-entrypoint "$@"

--- a/docker-images/php/magento-crontab
+++ b/docker-images/php/magento-crontab
@@ -1,0 +1,5 @@
+#!/bin/bash
+PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+
+* * * * * ! test -e /var/www/html/web/maintenance.flag && /bin/bash /var/www/html/web/scheduler_cron.sh --mode always
+* * * * * ! test -e /var/www/html/web/maintenance.flag && /bin/bash /var/www/html/web/scheduler_cron.sh --mode default


### PR DESCRIPTION
Fixes AOE Scheduler alert “No heartbeat task found. Check if cron is
configured correctly.”